### PR TITLE
Switch to nix-pypi-fetcher-2

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     mach-nix.url = "mach-nix";
     nixpkgs.url = "nixpkgs/nixos-unstable";
     nixpkgsPy36.url = "nixpkgs/b4db68ff563895eea6aab4ff24fa04ef403dfe14";
-    pypiIndex.url = "github:davhau/nix-pypi-fetcher";
+    pypiIndex.url = "github:davhau/nix-pypi-fetcher-2";
     pypiIndex.flake = false;
   };
 


### PR DESCRIPTION
nix-pypi-fetcher filled its GitHub storage quota and no longer receives updates.

Merge this in the fork so that GitHub Actions will respect the configuration and try to do a run.
